### PR TITLE
[FixedCircularArray] Fix shifting 'next' variable to a negative value in removeAt() method

### DIFF
--- a/collections/src/main/java/com/logcat/collections/FixedCircularArray.kt
+++ b/collections/src/main/java/com/logcat/collections/FixedCircularArray.kt
@@ -65,7 +65,12 @@ class FixedCircularArray<E>(val capacity: Int, initialSize: Int = INITIAL_SIZE) 
         }
         array[(head + size - 1) % capacity] = null
 
-        next--
+        if (next == 0) {
+            next = size - 1
+        } else {
+            next--
+        }
+
         if (next == head) {
             if (head >= 0) {
                 head--

--- a/collections/src/test/java/com/logcat/collections/FixedCircularArrayTest.kt
+++ b/collections/src/test/java/com/logcat/collections/FixedCircularArrayTest.kt
@@ -141,4 +141,22 @@ class FixedCircularArrayTest {
         assertTrue(1000 in array)
         assertTrue(900 !in array)
     }
+
+    @Test
+    fun testAddAfterRemove() {
+        val array = FixedCircularArray<Int>(5)
+
+        for (i in 1..5) {
+            array += i
+        }
+        assertTrue(array.isNotEmpty())
+
+        array.removeAt(0)
+        array += 6
+
+        val excepted = arrayOf(2, 3, 4, 5, 6)
+        for (i in 0 until array.size) {
+            assertEquals(excepted[i], array[i])
+        }
+    }
 }


### PR DESCRIPTION
Hi. If the `next` pointer is in the `0` position, then when you remove element, you must shift it into the `size - 1` position. The error was that it shifts into a negative value and raised an `IndexOutOfBoundsException`, if i added a new element to the array. 
I made a test that reproduces the error, and also made a patch that fixes it.