### PR TITLE
Fix share action always sharing latest saved log instead of selected one

### DIFF
--- a/app/src/main/java/com/dp/logcatapp/ui/screens/SavedLogsScreen.kt
+++ b/app/src/main/java/com/dp/logcatapp/ui/screens/SavedLogsScreen.kt
@@ -224,7 +224,7 @@ fun SavedLogsScreen(
             viewModel.exportLog = viewModel.selected.first()
           },
           onClickShare = {
-            val fileInfo = requireNotNull(savedLogs).logFiles.first()
+            val fileInfo = viewModel.selected.first()
             ShareUtils.shareSavedLogs(
               context = context,
               uri = fileInfo.info.path.toUri(),


### PR DESCRIPTION
# Summary of changes

changed the selection of the file to be shared. Previously the first file on the list (the newest due to timestamped names) was shared, no matter which file you selected. Now the (first) selected file is shared. (The share button disappears on multiple files being selected, so first() can only be the correct one.)

# Why 

User expects the selected file to be shared. Without the fix you can always only share the latest log file.

# Testing

Tested on my Pixel 7. Saved multiple logs. Shared one that was not the latest.

# Demo

<img width="360" height="800" alt="Screenshot_1773409835" src="https://github.com/user-attachments/assets/f701d0cc-df12-47f7-92c8-1d5524edd018" />
